### PR TITLE
Enable macOS, watchOS and tvOS platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "APIClient",
-    platforms: [.iOS(.v15), .macCatalyst(.v15)],
+    platforms: [.iOS(.v15), .macCatalyst(.v15), .macOS(.v12), .watchOS(.v8), .tvOS(.v15)],
     products: [
         .library(name: "APIClient", targets: ["APIClient"]),
     ],

--- a/Tests/APIClientTests/APIClientTests.swift
+++ b/Tests/APIClientTests/APIClientTests.swift
@@ -78,6 +78,10 @@ final class APIClientTests: XCTestCase {
     }
     
     func testDecodingWithVoidResponse() async throws {
+        #if os(watchOS)
+        throw XCTSkip("Mocker URLProtocol isn't being called for POST requests on watchOS")
+        #endif
+        
         // GIVEN
         let url = URL(string: "https://api.github.com/user")!
         Mock(url: url, dataType: .json, statusCode: 200, data: [


### PR DESCRIPTION
As there are no dependencies on iOS SDK, enabled other Apple platforms. In theory, with custom implementation of `URLSession.data(for:)` it could be ported to previous OS versions (requires Xcode 13.2) and [Linux](https://github.com/vox-humana/AppReviewPostman/blob/main/Sources/Postman/URLSession%2BAsync.swift#L11).
Unfortunately, seems that custom URLProtocol doesn't properly works with POST requests on watchOS and Mocker doesn't have any non-iOS tests to re-verify. All other tests work on all platforms.