### PR TITLE
URLSession asyncData implementation for older OS versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "APIClient",
-    platforms: [.iOS(.v15), .macCatalyst(.v15), .macOS(.v12), .watchOS(.v8), .tvOS(.v15)],
+    platforms: [.iOS(.v13), .macCatalyst(.v13), .macOS(.v10_15), .watchOS(.v6), .tvOS(.v13)],
     products: [
         .library(name: "APIClient", targets: ["APIClient"]),
     ],

--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -49,7 +49,11 @@ public actor APIClient {
     private func actuallySend(_ request: URLRequest) async throws -> (Data, URLResponse) {
         var request = request
         delegate.client(self, willSendRequest: &request)
-        return try await session.data(for: request, delegate: nil)
+        if #available(macOS 12.0, iOS 15.0, macCatalyst 15.0, watchOS 8.0, tvOS 15.0, *) {
+            return try await session.data(for: request, delegate: nil)
+        } else {
+            return try await session.asyncData(for: request)
+        }
     }
     
     private func makeRequest<T>(for request: Request<T>) async throws -> URLRequest {

--- a/Sources/APIClient/URLSession+Async.swift
+++ b/Sources/APIClient/URLSession+Async.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension URLSession {
+    @available(macOS, obsoleted: 12, message: "Use new URLSession data(for:) method instead")
+    @available(iOS, obsoleted: 15, message: "Use new URLSession data(for:) method instead")
+    @available(macCatalyst, obsoleted: 15, message: "Use new URLSession data(for:) method instead")
+    @available(watchOS, obsoleted: 8, message: "Use new URLSession data(for:) method instead")
+    @available(tvOS, obsoleted: 15, message: "Use new URLSession data(for:) method instead")
+    func asyncData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let cancellableTask = CancellableTask()
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                cancellableTask.task = dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else if let data = data, let response = response {
+                        continuation.resume(returning: (data, response))
+                    } else {
+                        continuation.resume(throwing: URLError(.badServerResponse))
+                    }
+                }
+                cancellableTask.task?.resume()
+            }
+        } onCancel: {
+            cancellableTask.task?.cancel()
+        }
+    }
+}
+
+private final class CancellableTask {
+    var task: URLSessionTask?
+}


### PR DESCRIPTION
Custom implementation of a compatible async `URLSession` method for using on older OS versions.
1. Doesn't include `URLSessionDelegate`
2. Not sure about thread safety of `URLSessionTask` access. [Initial proposal](https://github.com/apple/swift-evolution/blob/main/proposals/0304-structured-concurrency.md#cancellation-handlers) didn't require any wrapper. However, in the current implementation compiler doesn't allow to capture mutable `URLSessionTask` directly.
3. Haven't tested all platforms but on macOS 11 it passed all tests.

Requires Xcode 13.2 beta 2
> You can now use Swift Concurrency in applications that deploy to macOS 10.15, iOS 13, tvOS 13, and watchOS 6 or newer. This support includes async/await, actors, global actors, structured concurrency, and the task APIs. (70738378)

https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2-release-notes
