### PR TITLE
Update GitHub response models to respect API nullability

### DIFF
--- a/Tests/APIClientTests/GitHubAPI.swift
+++ b/Tests/APIClientTests/GitHubAPI.swift
@@ -73,16 +73,16 @@ public struct UserEmail: Decodable {
     public let email: String
     public let verified: Bool
     public let primary: Bool
-    public let visibility: String
+    public let visibility: String?
 }
 
 public struct User: Codable {
     public let id: Int
     public let login: String
-    public let name: String
-    public let hireable: Bool
-    public let location: String
-    public let bio: String
+    public let name: String?
+    public let hireable: Bool?
+    public let location: String?
+    public let bio: String?
 }
 
 // MARK: - APIClientDelegate


### PR DESCRIPTION
It fixes #4 and gives more reason for code (responses) generation from OpenAPI/Swagger definition 🙂

From [GitHub OpenAPI description](https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml):
```
public-user:
  title: Public User
  description: Public User
  type: object
  properties:
    login:
      type: string
    id:
      type: integer
    name:
      type: string
      nullable: true
    hireable:
      type: boolean
      nullable: true
    location:
      type: string
      nullable: true
    bio:
      type: string
      nullable: true
    ... 
```
and 
```
email:
  title: Email
  description: Email
  type: object
  properties:
    email:
      type: string
      format: email
      example: octocat@github.com
    primary:
      type: boolean
      example: true
    verified:
      type: boolean
      example: true
    visibility:
      type: string
      example: public
      nullable: true
```