### PR TITLE
Optional query value

### DIFF
--- a/Sources/APIClient/APIClient.swift
+++ b/Sources/APIClient/APIClient.swift
@@ -66,7 +66,7 @@ public actor APIClient {
         return try await makeRequest(url: url, method: request.method, body: request.body)
     }
 
-    private func makeURL(path: String, query: [String: String]?) throws -> URL {
+    private func makeURL(path: String, query: [String: String?]?) throws -> URL {
         guard let url = URL(string: path),
               var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             throw URLError(.badURL)

--- a/Sources/APIClient/Request.swift
+++ b/Sources/APIClient/Request.swift
@@ -7,10 +7,10 @@ import Foundation
 public struct Request<Response> {
     var method: String
     var path: String
-    var query: [String: String]?
+    var query: [String: String?]?
     var body: AnyEncodable?
 
-    public static func get(_ path: String, query: [String: String]? = nil) -> Request {
+    public static func get(_ path: String, query: [String: String?]? = nil) -> Request {
         Request(method: "GET", path: path, query: query)
     }
     


### PR DESCRIPTION
Query parameters without values are uncommon, but the `Request` type should allow them. This also matches up with the optional `value` property of `URLQueryItem`.
